### PR TITLE
change memberInterests to manually update the update date to preserve…

### DIFF
--- a/lib/interests.php
+++ b/lib/interests.php
@@ -81,7 +81,7 @@ function updateMemberInterests($conid, $personId, $personType, $loginId, $loginT
     // when you update the interests, force a re-notify of the change
     $updInterest = <<<EOS
 UPDATE memberInterests
-SET interested = ?, updateBy = ?, notifyDate = null, csvDate = null
+SET interested = ?, updateBy = ?, notifyDate = null, csvDate = null, updateDate = NOW()
 WHERE id = ?;
 EOS;
     $insInterest = <<<EOS
@@ -158,7 +158,7 @@ WHERE perid = ? AND conid = ?;
 EOS;
         $chgU = <<<EOS
 UPDATE memberInterests
-SET interested = ?, updateBy = ?, notifyDate = null, csvDate = null
+SET interested = ?, updateBy = ?, notifyDate = null, csvDate = null, updateDate = NOW()
 WHERE id = ?;
 EOS;
         $idU = <<<EOS

--- a/portal/scripts/updateFromCart.php
+++ b/portal/scripts/updateFromCart.php
@@ -425,7 +425,7 @@ if ($personType == 'p') {
 }
 $updInterest = <<<EOS
 UPDATE memberInterests
-SET interested = ?, updateBy = ?
+SET interested = ?, updateBy = ?, updateDate = NOW()
 WHERE id = ?;
 EOS;
 $insInterest = <<<EOS


### PR DESCRIPTION
pick to fix an issue in seattle production - updatedate as an auto update field is an issue, as it messes up interest change tracking, so it had to be come a manually updated field.