### PR TITLE
Patch to 2.3 to fix ConTroll reg_admin variable scope isse

### DIFF
--- a/controll/js/regadmin_merge.js
+++ b/controll/js/regadmin_merge.js
@@ -407,7 +407,7 @@ class mergesetup {
         }
         let html = '';
         let mpol = this.#mergePerson['policies'];
-        for (policy in mpol) {
+        for (let policy in mpol) {
             html += policy + ': ' + mpol[policy] + "<br/>";
         }
         this.#mergePolicies.innerHTML = html;
@@ -431,7 +431,7 @@ class mergesetup {
         }
         html = '';
         mpol = this.#remainPerson['policies'];
-        for (policy in mpol) {
+        for (let policy in mpol) {
             html += policy + ': ' + mpol[policy] + "<br/>";
         }
         this.#remainPolicies.innerHTML = html;

--- a/lib/jsVersions.php
+++ b/lib/jsVersions.php
@@ -20,7 +20,7 @@ function getTabulatorIncludes(): array {
 global $portalJSVersion, $libJSversion, $controllJSversion, $globalJSversion, $atJSversion, $exhibitorJSversion, $onlineregJSversion;
 $portalJSVersion = '2.3.0';
 $libJSversion = '2.3.0';
-$controllJSversion = '2.3.0';
+$controllJSversion = '2.3.1';
 $globalJSversion = '2.3.0';
 $atJSversion = '2.3.0';
 $exhibitorJSversion = '2.3.0';


### PR DESCRIPTION
Bug fix, finally got enough to close it. Merge wasn't locally scoping a 'var' variable used elsewhere. It overwrite a class with a string causing a javaqscript error.

This fixes that issue